### PR TITLE
升级兼容SkyAPM.Core 2.1.0版本

### DIFF
--- a/Serilog.Sinks.Skywalking/Serilog.Sinks.Skywalking.csproj
+++ b/Serilog.Sinks.Skywalking/Serilog.Sinks.Skywalking.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Serilog" Version="2.10.0" />
-		<PackageReference Include="SkyAPM.Core" Version="2.0.0" />
+		<PackageReference Include="SkyAPM.Core" Version="2.1.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
与SkyAPM.Core 2.1.0版本不兼容，并且在运行时报出异常错误

![08de565c5a262fb7e03e2690ed51c78](https://user-images.githubusercontent.com/22129824/217728428-3b685488-6a15-4bdc-a85a-199f6cdfc626.png)

可能是我之前提的issue的原因：

https://github.com/SpringHgui/serilog-sinks-skywalking/issues/1

另外调整了`ISkyApmLogDispatcher`,`IEntrySegmentContextAccessor`类的获取方式为必须，考虑在启动时未使用Skywalking却配置了日志输出，应直接抛出异常而不是默认不输出